### PR TITLE
Compatibilité kodi 19

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -6,7 +6,6 @@
     <requires>
         <import addon="xbmc.json" version="6.0.0"/>
         <import addon="xbmc.addon" version="12.0.0"/>
-        <import addon="script.module.kodi-six" version="0.1.3.1"/>
         <import addon="script.module.simplejson" version="3.17.0"/>
         <import addon="inputstream.adaptive" version="19.0.2"/>
     </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -6,10 +6,9 @@
     <requires>
         <import addon="xbmc.json" version="6.0.0"/>
         <import addon="xbmc.addon" version="12.0.0"/>
-        <import addon="script.module.kodi-six" />
+        <import addon="script.module.kodi-six" version="0.1.3.1"/>
         <import addon="script.module.simplejson" version="3.17.0"/>
         <import addon="inputstream.adaptive" version="19.0.2"/>
-        <import addon="script.module.web-pdb" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>

--- a/addon.xml
+++ b/addon.xml
@@ -4,8 +4,6 @@
        version="4.0.0"
        provider-name="dualB">
     <requires>
-        <import addon="xbmc.json" version="6.0.0"/>
-        <import addon="xbmc.addon" version="12.0.0"/>
         <import addon="script.module.simplejson" version="3.17.0"/>
         <import addon="inputstream.adaptive" version="19.0.2"/>
     </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -8,7 +8,7 @@
         <import addon="xbmc.addon" version="12.0.0"/>
         <import addon="script.module.kodi-six" />
         <import addon="script.module.simplejson" version="3.17.0"/>
-        <import addon="script.module.inputstreamhelper" version="0.5.2"/>
+        <import addon="inputstream.adaptive" version="19.0.2"/>
         <import addon="script.module.web-pdb" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">

--- a/addon.xml
+++ b/addon.xml
@@ -6,7 +6,8 @@
     <requires>
         <import addon="xbmc.json" version="6.0.0"/>
         <import addon="xbmc.addon" version="12.0.0"/>
-        <import addon="script.module.simplejson" version="3.16.1"/>
+        <import addon="script.module.kodi-six" />
+        <import addon="script.module.simplejson" version="3.17.0"/>
         <import addon="script.module.inputstreamhelper" version="0.5.2"/>
         <import addon="script.module.web-pdb" />
     </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -8,6 +8,7 @@
         <import addon="xbmc.addon" version="12.0.0"/>
         <import addon="script.module.simplejson" version="3.16.1"/>
         <import addon="script.module.inputstreamhelper" version="0.5.2"/>
+        <import addon="script.module.web-pdb" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>

--- a/default.py
+++ b/default.py
@@ -2,11 +2,16 @@
 
 # version 3.2.2 - By dualB
 
-import os, sys, traceback, simplejson
+import os, sys, traceback
 import xbmcaddon, xbmcplugin, xbmcvfs
 
 from resources.lib.log import log
 from resources.lib import content, navig
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 if sys.version_info.major >= 3:
     # Python 3 stuff
@@ -79,7 +84,7 @@ try:
 except Exception:
     pass
 
-filtres = simplejson.loads(FILTERS)
+filtres = json.loads(FILTERS)
 
 if SOURCE_ID !='':
     navig.jouer_video(URL,SOURCE_ID)

--- a/default.py
+++ b/default.py
@@ -2,7 +2,7 @@
 
 # version 3.2.2 - By dualB
 
-import os, sys, traceback, xbmcplugin, xbmcaddon, xbmc, simplejson, xbmcgui, web_pdb
+import os, sys, traceback, xbmcplugin, xbmcaddon, xbmc, simplejson, xbmcgui, web_pdb, xbmcvfs
 
 from resources.lib.log import log
 from resources.lib import content, navig
@@ -16,7 +16,7 @@ else:
 
 ADDON = xbmcaddon.Addon()
 
-web_pdb.set_trace()
+
 
 def get_params():
     """ function docstring """
@@ -95,7 +95,7 @@ if MODE != 99:
     xbmcplugin.endOfDirectory(int(sys.argv[1]))
 
 if MODE != 4 and xbmcaddon.Addon().getSetting('DeleteTempFiFilesEnabled') == 'true':
-    PATH = xbmc.translatePath('special://temp').decode('utf-8')
+    PATH = xbmcvfs.translatePath('special://temp').decode('utf-8')
     FILENAMES = next(os.walk(PATH))[2]
     for i in FILENAMES:
         if ".fi" in i:

--- a/default.py
+++ b/default.py
@@ -2,7 +2,7 @@
 
 # version 3.2.2 - By dualB
 
-import os, sys, traceback, simplejson, web_pdb
+import os, sys, traceback, simplejson
 from kodi_six import xbmcaddon, xbmcplugin, xbmcvfs, xbmc
 
 from resources.lib.log import log

--- a/default.py
+++ b/default.py
@@ -2,7 +2,8 @@
 
 # version 3.2.2 - By dualB
 
-import os, sys, traceback, xbmcplugin, xbmcaddon, xbmc, simplejson, xbmcgui, web_pdb, xbmcvfs
+import os, sys, traceback, simplejson, web_pdb
+from kodi_six import xbmcaddon, xbmcplugin, xbmcvfs, xbmc
 
 from resources.lib.log import log
 from resources.lib import content, navig

--- a/default.py
+++ b/default.py
@@ -2,7 +2,7 @@
 
 # version 3.2.2 - By dualB
 
-import os, sys, traceback, xbmcplugin, xbmcaddon, xbmc, simplejson, xbmcgui
+import os, sys, traceback, xbmcplugin, xbmcaddon, xbmc, simplejson, xbmcgui, web_pdb
 
 from resources.lib.log import log
 from resources.lib import content, navig
@@ -15,6 +15,8 @@ else:
     from urllib import quote_plus, unquote_plus, unquote
 
 ADDON = xbmcaddon.Addon()
+
+web_pdb.set_trace()
 
 def get_params():
     """ function docstring """

--- a/default.py
+++ b/default.py
@@ -3,7 +3,7 @@
 # version 3.2.2 - By dualB
 
 import os, sys, traceback, simplejson
-from kodi_six import xbmcaddon, xbmcplugin, xbmcvfs, xbmc
+import xbmcaddon, xbmcplugin, xbmcvfs
 
 from resources.lib.log import log
 from resources.lib import content, navig

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -2,7 +2,7 @@
 # version 3.2.2 - By dualB
 
 import os, time, sys, io
-from kodi_six import xbmcaddon, xbmcvfs, xbmc
+import xbmcaddon, xbmcvfs
 from . import log, html
 
 ADDON = xbmcaddon.Addon()

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # version 3.2.2 - By dualB
 
-import xbmcaddon, os, xbmc, time, sys
+import xbmcaddon, os, xbmc, time, sys, xbmcvfs
 from . import log, html
 
 ADDON = xbmcaddon.Addon()
 
-ADDON_CACHE_BASEDIR = os.path.join(xbmc.translatePath(ADDON.getAddonInfo('path')), ".cache")
+ADDON_CACHE_BASEDIR = os.path.join(xbmcvfs.translatePath(ADDON.getAddonInfo('path')), ".cache")
 ADDON_CACHE_TTL = float(ADDON.getSetting('CacheTTL').replace("0", ".5").replace("73", "0"))
 
 if not os.path.exists(ADDON_CACHE_BASEDIR):

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -33,14 +33,18 @@ def get_cached_content(path,verified=True,headers=[]):
         filename = get_cached_filename(path)
         if os.path.exists(filename) and not is_cached_content_expired(os.path.getmtime(filename)):
             log.log('Lecture en CACHE du contenu suivant :' + path)
-            content = open(filename).read()
+            with io.open(filename, 'r', encoding='utf-8') as fo:
+                content = fo.read()
         else:
+            
             log.log('Lecture en LIGNE du contenu suivant :' + path)
             content = html.get_url_txt(path,verified,headers)
             if len(content)>0:
                 try:
                     if sys.version >= "3":
-                        file(filename, "w").write(content) # cache the requested web content
+                        with io.open(filename, 'w', encoding='utf-8') as fo:
+                            fo.write(content)
+                            # open(filename, "w", encoding="utf-8").write(content) # cache the requested web content
                     else:
                         open(filename, "w").write(content) # cache the requested web content
                 except Exception:

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # version 3.2.2 - By dualB
 
-import xbmcaddon, os, xbmc, time, sys, xbmcvfs
+import os, time, sys, io
+from kodi_six import xbmcaddon, xbmcvfs, xbmc
 from . import log, html
 
 ADDON = xbmcaddon.Addon()
@@ -27,6 +28,7 @@ def is_cached_content_expired(last_update):
 def get_cached_content(path,verified=True,headers=[]):
     """ function docstring """
     content = None
+    
     try:
         filename = get_cached_filename(path)
         if os.path.exists(filename) and not is_cached_content_expired(os.path.getmtime(filename)):
@@ -51,5 +53,6 @@ def get_cached_content(path,verified=True,headers=[]):
 
 def get_cached_filename(path):
     """ function docstring """
-    filename = "%s" % _hash(repr(path)).hexdigest()
+    utfName = repr(path).encode('utf-8')
+    filename = "%s" % _hash(utfName).hexdigest()
     return os.path.join(ADDON_CACHE_BASEDIR, filename)

--- a/resources/lib/clearcache.py
+++ b/resources/lib/clearcache.py
@@ -9,7 +9,7 @@ import xbmcvfs
 from xbmcaddon import Addon
 
 addon = Addon('plugin.video.telequebec')
-addon_cache_basedir = os.path.join(xbmc.translatePath(addon.getAddonInfo('path')).decode('utf-8'),".cache")
+addon_cache_basedir = os.path.join(xbmcvfs.translatePath(addon.getAddonInfo('path')).decode('utf-8'),".cache")
 
 if sys.argv[1].lower() == "full":
     print("["+addon.getAddonInfo('name')+"] deleting full cache")

--- a/resources/lib/clearcache.py
+++ b/resources/lib/clearcache.py
@@ -2,10 +2,7 @@
 
 import os
 import sys
-
-import xbmc
-import xbmcgui
-import xbmcvfs
+from kodi_six import xbmc, xbmcaddon, xbmcgui, xbmcvfs
 from xbmcaddon import Addon
 
 addon = Addon('plugin.video.telequebec')

--- a/resources/lib/clearcache.py
+++ b/resources/lib/clearcache.py
@@ -12,7 +12,7 @@ addon = Addon('plugin.video.telequebec')
 addon_cache_basedir = os.path.join(xbmc.translatePath(addon.getAddonInfo('path')).decode('utf-8'),".cache")
 
 if sys.argv[1].lower() == "full":
-    print "["+addon.getAddonInfo('name')+"] deleting full cache"
+    print("["+addon.getAddonInfo('name')+"] deleting full cache")
     for root, dirs, files in os.walk(addon_cache_basedir):
         for file in files:
             xbmcvfs.delete(os.path.join(root,file))

--- a/resources/lib/clearcache.py
+++ b/resources/lib/clearcache.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from kodi_six import xbmc, xbmcaddon, xbmcgui, xbmcvfs
+import xbmcaddon, xbmcgui, xbmcvfs
 from xbmcaddon import Addon
 
 addon = Addon('plugin.video.telequebec')

--- a/resources/lib/content.py
+++ b/resources/lib/content.py
@@ -2,7 +2,7 @@
 # version 3.2.2 - By dualB
 
 import sys, re
-from kodi_six import xbmc, xbmcaddon
+import xbmcaddon
 from . import cache, html, log, parse
 
 try:

--- a/resources/lib/content.py
+++ b/resources/lib/content.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 # version 3.2.2 - By dualB
 
-import sys, simplejson, re, xbmcaddon,xbmc
+import sys, re
+from kodi_six import xbmc, xbmcaddon
 from . import cache, html, log, parse
-import simplejson as json
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 if sys.version_info.major >= 3:
     # Python 3 stuff
@@ -252,17 +257,18 @@ def getImage(url,width,height):
     return link
     
 def getShow(mediaBundleId):
-    database = simplejson.loads(cache.get_cached_content(MEDIA_BUNDLE_URL + str(mediaBundleId)))
+    database = json.loads(cache.get_cached_content(MEDIA_BUNDLE_URL + str(mediaBundleId)))
     return database['data']
 
 def getLinkPop(url):
-    database = simplejson.loads(cache.get_cached_content(POPULAIRE_URL + str(url)))
+    
+    database = json.loads(cache.get_cached_content(POPULAIRE_URL + str(url)))
     return database['data'][0]
 
 def getJsonBlock(url, block):
     dataBlock = []
     try:
-        db = simplejson.loads(cache.get_cached_content(url))
+        db = json.loads(cache.get_cached_content(url))
         dataBlock = db['data'][block]['items']
     except Exception:
         dataBlock = []

--- a/resources/lib/html.py
+++ b/resources/lib/html.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # version 3.2.2 - By dualB
 
-import sys, re, socket, xbmc, ssl
+import sys, re, socket, ssl
+from kodi_six import xbmc
 from . import log
 
 if sys.version_info.major >= 3:

--- a/resources/lib/html.py
+++ b/resources/lib/html.py
@@ -2,7 +2,6 @@
 # version 3.2.2 - By dualB
 
 import sys, re, socket, ssl
-from kodi_six import xbmc
 from . import log
 
 if sys.version_info.major >= 3:

--- a/resources/lib/log.py
+++ b/resources/lib/log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # version 3.2.2 - By dualB
 
-from kodi_six import xbmc, xbmcaddon
+import xbmc, xbmcaddon
 
 def log(msg):
     """ function docstring """

--- a/resources/lib/log.py
+++ b/resources/lib/log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # version 3.2.2 - By dualB
 
-import xbmcaddon, xbmc
+from kodi_six import xbmc, xbmcaddon
 
 def log(msg):
     """ function docstring """

--- a/resources/lib/navig.py
+++ b/resources/lib/navig.py
@@ -189,7 +189,6 @@ def liveStreamURL():
     return 'https://bcovlive-a.akamaihd.net/575d86160eb143458d51f7ab187a4e68/us-east-1/6101674910001/' + obtenirMeilleurStream(a,'profile')
    
 def jouer_video(url,media_uid):
-    #import web_pdb; web_pdb.set_trace()
     if "live" in url:
         jouer_live()
     else:

--- a/resources/lib/navig.py
+++ b/resources/lib/navig.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # version 3.2.2 - By dualB
 
-import sys, xbmcgui, xbmcplugin, xbmcaddon, re, simplejson, xbmc
+import sys, re, simplejson
+from kodi_six import xbmc, xbmcaddon, xbmcplugin, xbmcgui
 from . import log, parse, content, cache
 
 if sys.version_info.major >= 3:
@@ -135,7 +136,9 @@ def ajouterVideo(show):
         resume = name.lstrip()
 
     liz = xbmcgui.ListItem(\
-        remove_any_html_tags(name), iconImage=ADDON_IMAGES_BASEPATH+"default-video.png", thumbnailImage=iconimage)
+        # remove_any_html_tags(name), iconImage=ADDON_IMAGES_BASEPATH+"default-video.png", thumbnailImage=iconimage)
+        remove_any_html_tags(name))
+    liz.setArt({'icon': ADDON_IMAGES_BASEPATH+"default-video.png"})
     liz.setInfo(\
         type="Video",\
         infoLabels={\
@@ -194,8 +197,8 @@ def jouer_video(url,media_uid):
         if uri:
             item = xbmcgui.ListItem(\
                 video_json['title'],\
-                iconImage=thumbnail_url,\
-                thumbnailImage=thumbnail_url, path=uri)
+                path=uri)
+            item.setArt({'icon': thumbnail_url})
             play_item = xbmcgui.ListItem(path=uri)
             xbmcplugin.setResolvedUrl(__handle__,True, item)
         else:

--- a/resources/lib/navig.py
+++ b/resources/lib/navig.py
@@ -2,7 +2,7 @@
 # version 3.2.2 - By dualB
 
 import sys, re
-from kodi_six import xbmc, xbmcaddon, xbmcplugin, xbmcgui
+import xbmc, xbmcaddon, xbmcplugin, xbmcgui
 from . import log, parse, content, cache
 
 try:

--- a/resources/lib/navig.py
+++ b/resources/lib/navig.py
@@ -143,7 +143,8 @@ def ajouterVideo(show):
     liz = xbmcgui.ListItem(\
         # remove_any_html_tags(name), iconImage=ADDON_IMAGES_BASEPATH+"default-video.png", thumbnailImage=iconimage)
         remove_any_html_tags(name))
-    liz.setArt({'icon': ADDON_IMAGES_BASEPATH+"default-video.png"})
+    #liz.setArt({'icon': ADDON_IMAGES_BASEPATH+"default-video.png"})
+    liz.setArt({ 'thumb' : iconimage } )
     liz.setInfo(\
         type="Video",\
         infoLabels={\
@@ -220,8 +221,6 @@ def getURI(video_json,refID):
             return m3u8BC(stream['sourceId'])       
     
 def m3u8BC(sourceId):
-    if sourceId == '6155415616001':
-        import web_pdb; web_pdb.set_trace()
     config = getBrightcoveConfig()
     log.log('KEY : %s' % config['key'])
     log.log('Ad_Config_ID : %s' %config['ad'])

--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -31,7 +31,7 @@ def ListeVideosGroupees(filtres):
     if index >= len(filtresShow):
         return liste
     else:
-        groupBy = filtresShow.keys()[index]
+        groupBy = list(filtresShow)[index]
         showsGroupes = {}
         cle = ''
         

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <!-- APPARENCE -->
-    <category label="32100">
-        <setting label="32101" type="bool" id="FanartEnabled" default="true"/>
-        <setting label="32102" type="bool" id="FanartEmissionsEnabled" default="true" enable="eq(-1,true)"/>
-        <setting label="32114" type="bool" id="EmissionNameInPlotEnabled" default="true"/>
-        <setting label="32116" type="select" id="MaxResolution" values="480|540|720|1080" default="1080"/>
+    <category label="Apparence">
+        <setting label="Activer le fanart de l'addiciel" type="bool" id="FanartEnabled" default="true"/>
+        <setting label="Si disponible, utiliser l'image de l'émission en fanart" type="bool" id="FanartEmissionsEnabled" default="true" enable="eq(-1,true)"/>
+        <setting label="Afficher le nom de l'émission dans le section descriptive" type="bool" id="EmissionNameInPlotEnabled" default="true"/>
+        <setting label="Résolution maximale" type="select" id="MaxResolution" values="480|540|720|1080" default="1080"/>
     </category> 
 
     <!-- ADVANCE -->
-    <category label="32110">
-        <setting label="32122" type="bool" id="DeleteTempFiFilesEnabled" default="false"/>
-        <setting label="32106" type="enum" id="CacheTTL" lvalues="32200|32201|32202|32203|32204|32205|32206|32207|32208|32209|32210|32211|32212|32213|32214|32215|32216|32217|32218|32219|32220|32221|32222|32223|32224|32225|32226|32227|32228|32229|32230|32231|32232|32233|32234|32235|32236|32237|32238|32239|32240|32241|32242|32243|32244|32245|32246|32247|32248|32249|32250|32251|32252|32253|32254|32255|32256|32257|32258|32259|32260|32261|32262|32263|32264|32265|32266|32267|32268|32269|32270|32271|32272|32273" default="24" />
-        <setting label="32107" type="action" action="RunScript($CWD/resources/lib/clearcache.py,full)" default="" />
+    <category label="Paramètres Avancés">
+        <setting label="Auto-supprimer les fichiers temporaires .fi de Kodi" type="bool" id="DeleteTempFiFilesEnabled" default="false"/>
+        <setting label="Durée de vie des informations gardées en cache" type="enum" id="CacheTTL" lvalues="32200|32201|32202|32203|32204|32205|32206|32207|32208|32209|32210|32211|32212|32213|32214|32215|32216|32217|32218|32219|32220|32221|32222|32223|32224|32225|32226|32227|32228|32229|32230|32231|32232|32233|32234|32235|32236|32237|32238|32239|32240|32241|32242|32243|32244|32245|32246|32247|32248|32249|32250|32251|32252|32253|32254|32255|32256|32257|32258|32259|32260|32261|32262|32263|32264|32265|32266|32267|32268|32269|32270|32271|32272|32273" default="24" />
+        <setting label="Nettoyer le cache maintenant!" type="action" action="RunScript($CWD/resources/lib/clearcache.py,full)" default="" />
         <setting type="lsep" /> -->
-        <setting label="32115" type="bool" id="NetworkDetection" default="true"/>
-        <setting label="32104" type="bool" id="DebugMode" default="false"/>
+        <setting label="Afficher un message au démarrage" type="bool" id="NetworkDetection" default="true"/>
+        <setting label="Mode débogue - Consultez le fichier des logs de Kodi" type="bool" id="DebugMode" default="false"/>
     </category> 
 
 </settings>


### PR DESCRIPTION
Bonjour, j'ai décidé d'essayer de ressusciter l'add-on pour kodi 19.
J'ai réussi à rétablir le fonctionnement de base, la plupart des vidéos fonctionnent, mais il reste du travail, surtout au niveau de la récupération du contenu.

À noter que j'ai 0 expérience avec Python et le développement d'add-on kodi, donc il est possible que mes corrections ne soient pas optimales.

Ce que j'ai fait :
- Recherche et correction du code incompatible avec Python 3.
- Recherche et correction du code obsolète.
- Rétablissement de la dépendance inputstream.adaptative (vraiment pas certain que c'est la meilleure idée mais je ne savais pas trop quoi faire avec inputstreamhelper).
- Ménage des dépendances et numéros de version plus récents.

À faire :
- Convertir les fichiers de localisation au bon format pour kodi 19 (hardcodé dans settings.xml en attendant)
- Réparer la section "A à Z - Toutes les catégories".
- Réparer la récupération et le filtrage du contenu, je crois qu'il manque des séries/émissions et que certains contenus sont listés mais injouables/inaccessibles.
- Bumper le numéro de version ?

Voilà !